### PR TITLE
Populate the signature field in Cloud IOC

### DIFF
--- a/default/props.conf
+++ b/default/props.conf
@@ -5,13 +5,14 @@ KV_MODE = none
 category = Network & Security
 description = Output produced by the Cisco Advanced Malware Protection (AMP) for Endpoints
 
-FIELDALIAS-event_type_as_category            = "event.event_type"           AS category
-FIELDALIAS-computer_hostname_as_dest         = "event.computer.hostname"    AS dest
-FIELDALIAS-file_identity_sha256_as_file_hash = "event.file.identity.sha256" AS file_hash
-FIELDALIAS-file_file_name_as_file_name       = "event.file.file_name"       AS file_name
-FIELDALIAS-file_file_path_as_file_path       = "event.file.file_path"       AS file_path
-FIELDALIAS-detection_as_signature            = "event.detection"            AS signature
-FIELDALIAS-computer_user_as_user             = "event.computer.user"        AS user
+FIELDALIAS-event_type_as_category            = "event.event_type"                   AS category
+FIELDALIAS-computer_hostname_as_dest         = "event.computer.hostname"            AS dest
+FIELDALIAS-file_identity_sha256_as_file_hash = "event.file.identity.sha256"         AS file_hash
+FIELDALIAS-file_file_name_as_file_name       = "event.file.file_name"               AS file_name
+FIELDALIAS-file_file_path_as_file_path       = "event.file.file_path"               AS file_path
+FIELDALIAS-detection_as_signature            = "event.detection"                    AS signature
+FIELDALIAS-short_description_as_signature    = "event.cloud_ioc.short_description"  AS signature
+FIELDALIAS-computer_user_as_user             = "event.computer.user"                AS user
 
 EVAL-vendor_product = "Cisco AMP for Endpoints"
 


### PR DESCRIPTION
Fixes #12 Populates the signature field in Cloud IOC events with the contents of the short_description.